### PR TITLE
Refactor: Remove unused method and consolidate conversion logic

### DIFF
--- a/src/03/z2ui5_cl_layo_manager.clas.abap
+++ b/src/03/z2ui5_cl_layo_manager.clas.abap
@@ -877,30 +877,12 @@ CLASS z2ui5_cl_layo_manager IMPLEMENTATION.
 
   METHOD convert.
 
-    DATA(conex) = COND #( WHEN i_output = abap_true
-                          THEN |CONVERSION_EXIT_{ i_layout-convexit }_OUTPUT|
-                          ELSE |CONVERSION_EXIT_{ i_layout-convexit }_INPUT| ).
-
-    TRY.
-        IF i_layout-convexit = 'CUNIT'.
-
-          CALL FUNCTION conex
-            EXPORTING  input    = c_value
-                       language = sy-langu
-            IMPORTING  output   = c_value
-            EXCEPTIONS OTHERS   = 99.
-
-        ELSE.
-
-          CALL FUNCTION conex
-            EXPORTING  input  = c_value
-            IMPORTING  output = c_value
-            EXCEPTIONS OTHERS = 99.
-
-        ENDIF.
-
-      CATCH cx_root.
-    ENDTRY.
+    z2ui5_cl_util=>conv_exit(
+      EXPORTING
+        convexit = i_layout-convexit
+        output   = i_output
+      CHANGING
+        value    = c_value ).
 
   ENDMETHOD.
 

--- a/src/03/z2ui5_cl_layo_pop.clas.abap
+++ b/src/03/z2ui5_cl_layo_pop.clas.abap
@@ -114,12 +114,6 @@ CLASS z2ui5_cl_layo_pop DEFINITION
     METHODS render_add_gridlayout.
     METHODS update_values.
 
-    CLASS-METHODS get_relative_name_of_table
-      IMPORTING
-        !table        TYPE any
-      RETURNING
-        VALUE(result) TYPE string.
-
   PRIVATE SECTION.
     METHODS check_grid_sum
       IMPORTING
@@ -877,32 +871,6 @@ CLASS z2ui5_cl_layo_pop IMPLEMENTATION.
     IF sy-subrc = 0.
       COMMIT WORK AND WAIT.
     ENDIF.
-
-  ENDMETHOD.
-
-  METHOD get_relative_name_of_table.
-
-    FIELD-SYMBOLS <table> TYPE any.
-
-    TRY.
-        DATA(typedesc) = cl_abap_typedescr=>describe_by_data( table ).
-
-        CASE typedesc->kind.
-
-          WHEN cl_abap_typedescr=>kind_table.
-            DATA(tabledesc) = CAST cl_abap_tabledescr( typedesc ).
-            DATA(structdesc) = CAST cl_abap_structdescr( tabledesc->get_table_line_type( ) ).
-            result = structdesc->get_relative_name( ).
-            RETURN.
-
-          WHEN typedesc->kind_ref.
-
-            ASSIGN table->* TO <table>.
-            result = get_relative_name_of_table( <table> ).
-
-        ENDCASE.
-      CATCH cx_root.
-    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
This PR refactors the codebase by removing an unused utility method and consolidating conversion logic into a shared utility function, improving code maintainability and reducing duplication.

## Key Changes
- **Removed unused method**: Deleted `get_relative_name_of_table()` class method from `z2ui5_cl_layo_pop` that was not being called anywhere in the codebase
- **Consolidated conversion logic**: Replaced inline conversion exit handling in `z2ui5_cl_layo_manager=>convert()` with a call to the centralized `z2ui5_cl_util=>conv_exit()` utility method
  - Eliminates duplicate conversion logic
  - Simplifies the convert method from 28 lines to 8 lines
  - Maintains the same functionality for both CUNIT and standard conversion exits

## Implementation Details
The conversion logic consolidation handles:
- Dynamic construction of conversion exit function names based on input/output mode
- Special handling for CUNIT conversion exits (requires language parameter)
- Standard conversion exit handling for other types
- Error suppression for missing or invalid conversion functions

This refactoring improves code clarity and makes future maintenance of conversion logic easier by centralizing it in a single utility method.

https://claude.ai/code/session_01T3f6uWKeqTiwjiBvp7miiH