### PR TITLE
fix(downport): resolve two non-auto-fixable abaplint errors in layo_manager

### DIFF
--- a/src/03/z2ui5_cl_layo_manager.clas.abap
+++ b/src/03/z2ui5_cl_layo_manager.clas.abap
@@ -734,7 +734,6 @@ CLASS z2ui5_cl_layo_manager IMPLEMENTATION.
         SORT <table>
              BY (sortorder).
 
-      CATCH cx_sy_dyn_table_ill_comp_val. "##NO_HANDLER
       CATCH cx_root.
     ENDTRY.
 
@@ -797,6 +796,8 @@ CLASS z2ui5_cl_layo_manager IMPLEMENTATION.
 
   METHOD data_conversion.
 
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+
     ASSIGN mr_data->* TO FIELD-SYMBOL(<any>).
 
     IF <any> IS NOT ASSIGNED.
@@ -846,7 +847,12 @@ CLASS z2ui5_cl_layo_manager IMPLEMENTATION.
       CASE ms_layout-s_head-control.
         WHEN ui_table OR m_table.
 
-          LOOP AT <any> ASSIGNING FIELD-SYMBOL(<line>).
+          ASSIGN mr_data->* TO <tab>.
+          IF <tab> IS NOT ASSIGNED.
+            CONTINUE.
+          ENDIF.
+
+          LOOP AT <tab> ASSIGNING FIELD-SYMBOL(<line>).
 
             ASSIGN COMPONENT layout-fname OF STRUCTURE <line> TO FIELD-SYMBOL(<value>).
             IF <value> IS NOT ASSIGNED.


### PR DESCRIPTION
## Problem

The `auto_downport` workflow failed because `abaplint --fix` ended with exit code 1: two issues in `src/03/z2ui5_cl_layo_manager.clas.abap` cannot be auto-fixed, so the run aborted before the chained `syfixes` / `strip_trailing_ws` steps could run.

From the failed run log:
```
src/03/z2ui5_cl_layo_manager.clas.abap[966, 13]  - CATCH, unknown class CX_SY_DYN_TABLE_ILL_COMP_VAL (check_syntax) [E]
src/03/z2ui5_cl_layo_manager.clas.abap[1061, 25] - Variable "<LINE>" contains unknown: Type error, not a table type <any> (unknown_types) [E]
```

## Changes

Both in `src/03/z2ui5_cl_layo_manager.clas.abap`:

1. **`SORT <table>` TRY-block** — dropped `CATCH cx_sy_dyn_table_ill_comp_val. "##NO_HANDLER"`. That class does not exist in the v702 dependency set (open-abap-core / abap2UI5@702), so there is nothing to downport and abaplint reports it as an unknown class. The immediately following `CATCH cx_root.` already catches it (both handlers are empty), so there is no behavioral change.

2. **`data_conversion` method** — `LOOP AT <any>` looped over a field-symbol typed as generic `any`, which the v702 syntax check rejects (`not a table type`). Introduced a dedicated `FIELD-SYMBOLS <tab> TYPE ANY TABLE`, assigned `mr_data->*` to it in the `ui_table` branch, and loop over `<tab>` instead. The `ui_simpleform` branch (`ASSIGN COMPONENT ... OF STRUCTURE <any>`) is unchanged.

## Verification

The downport could not be run end-to-end in the dev environment because cloning the abaplint dependencies (`open-abap-core`, `abap2UI5@702`) is blocked by the egress policy (403). The changes target exactly the two errors reported in CI; running the `auto_downport` workflow on `main` after merge will confirm a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFYpa6zatGTCGkdNDhMEDj)_