### PR TITLE
Refactor search filtering logic to use utility method

### DIFF
--- a/src/03/z2ui5_cl_layo_pop.clas.abap
+++ b/src/03/z2ui5_cl_layo_pop.clas.abap
@@ -439,33 +439,14 @@ CLASS z2ui5_cl_layo_pop IMPLEMENTATION.
 
   METHOD Search.
 
-    FIELD-SYMBOLS <row> TYPE any.
-
     mt_layout = mo_layout->ms_layout-t_layout.
 
-    LOOP AT mt_layout ASSIGNING <row>.
-      DATA(lv_row) = ``.
-
-      ASSIGN COMPONENT 'FNAME' OF STRUCTURE <row> TO FIELD-SYMBOL(<fname>).
-      IF sy-subrc <> 0.
-        EXIT.
-      ENDIF.
-      ASSIGN COMPONENT 'ROLLNAME' OF STRUCTURE <row> TO FIELD-SYMBOL(<rollname>).
-      IF sy-subrc <> 0.
-        EXIT.
-      ENDIF.
-      ASSIGN COMPONENT 'TLABEL' OF STRUCTURE <row> TO FIELD-SYMBOL(<tlabel>).
-      IF sy-subrc <> 0.
-        EXIT.
-      ENDIF.
-
-      lv_row = lv_row && <fname> && <rollname> && <tlabel>.
-
-      IF lv_row NS client->get_event_arg( 1 ).
-        DELETE mt_layout.
-      ENDIF.
-
-    ENDLOOP.
+    z2ui5_cl_util=>itab_filter_by_search_string(
+      EXPORTING
+        val    = client->get_event_arg( 1 )
+        fields = VALUE #( ( `FNAME` ) ( `ROLLNAME` ) ( `TLABEL` ) )
+      CHANGING
+        tab    = mt_layout ).
 
     client->popup_model_update( ).
 

--- a/src/03/z2ui5_cl_layo_pop.clas.abap
+++ b/src/03/z2ui5_cl_layo_pop.clas.abap
@@ -441,7 +441,7 @@ CLASS z2ui5_cl_layo_pop IMPLEMENTATION.
 
     mt_layout = mo_layout->ms_layout-t_layout.
 
-    z2ui5_cl_util=>itab_filter_by_search_string(
+    z2ui5_cl_util=>itab_filter_by_val(
       EXPORTING
         val    = client->get_event_arg( 1 )
         fields = VALUE #( ( `FNAME` ) ( `ROLLNAME` ) ( `TLABEL` ) )

--- a/src/03/z2ui5_cl_layo_pop_w_sel.clas.abap
+++ b/src/03/z2ui5_cl_layo_pop_w_sel.clas.abap
@@ -298,8 +298,8 @@ CLASS z2ui5_cl_layo_pop_w_sel IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val = mv_search_value
-                                                 CHANGING  tab = <tab> ).
+    z2ui5_cl_util=>itab_filter_by_val( EXPORTING val = mv_search_value
+                                       CHANGING  tab = <tab> ).
 
   ENDMETHOD.
 

--- a/src/03/z2ui5_cl_layo_pop_w_sel.clas.abap
+++ b/src/03/z2ui5_cl_layo_pop_w_sel.clas.abap
@@ -298,22 +298,8 @@ CLASS z2ui5_cl_layo_pop_w_sel IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    LOOP AT <tab> ASSIGNING FIELD-SYMBOL(<f_row>).
-      DATA(lv_row) = ``.
-      DATA(lv_index) = 1.
-      DO.
-        ASSIGN COMPONENT lv_index OF STRUCTURE <f_row> TO FIELD-SYMBOL(<field>).
-        IF sy-subrc <> 0.
-          EXIT.
-        ENDIF.
-        lv_row = lv_row && <field>.
-        lv_index = lv_index + 1.
-      ENDDO.
-
-      IF lv_row NS mv_search_value.
-        DELETE <tab>.
-      ENDIF.
-    ENDLOOP.
+    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val = mv_search_value
+                                                 CHANGING  tab = <tab> ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
Refactored duplicate search filtering logic in two layout popup classes to use a centralized utility method, improving code maintainability and reducing duplication.

## Key Changes
- **z2ui5_cl_layo_pop.clas.abap**: Replaced manual loop-based filtering of `mt_layout` table with call to `z2ui5_cl_util=>itab_filter_by_val()` utility method, filtering by `FNAME`, `ROLLNAME`, and `TLABEL` fields
- **z2ui5_cl_layo_pop_w_sel.clas.abap**: Replaced manual loop-based filtering of `<tab>` with call to the same utility method, filtering across all table components

## Implementation Details
- Both implementations previously used similar patterns: looping through table rows, concatenating field values, and deleting rows that didn't match the search criteria
- The new utility method `itab_filter_by_val()` encapsulates this filtering logic with support for:
  - Specifying which fields to search (via `fields` parameter) or searching all fields (when `fields` is not provided)
  - Passing the search value and table as parameters
- This change reduces code duplication and centralizes the filtering logic for easier maintenance and potential future enhancements

https://claude.ai/code/session_01QPSE7jazyDMaQKojXzodTs